### PR TITLE
Use lazy % formatting for `logging` calls

### DIFF
--- a/src/apb/entrypoint.py
+++ b/src/apb/entrypoint.py
@@ -22,7 +22,7 @@ def get_repo_list(
     g: Github, repo_query: str
 ) -> Generator[Repository.Repository, None, None]:
     """Generate a list of repositories based on the query."""
-    print(f"Querying for repositories: {repo_query}")
+    logging.info("Querying for repositories: %s", repo_query)
     matching_repos = g.search_repositories(query=repo_query)
     for repo in matching_repos:
         yield repo


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request convert all calls using the `logging` library to use lazy % formatting instead of f-strings. It also ensures that we use `logging` calls instead of `print()` statements.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The use of % formatting in `logging` calls is preferred for a number of reasons. This also brings this project in line with our other Python projects that already follow this preference.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
