### PR TITLE
Add GitHub Actions specific logging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -87,6 +87,7 @@ setup(
     py_modules=[splitext(basename(path))[0] for path in glob("src/*.py")],
     include_package_data=True,
     install_requires=[
+        "actions-toolkit",
         "Babel",
         "PyGithub",
         "python-dateutil",

--- a/src/apb/entrypoint.py
+++ b/src/apb/entrypoint.py
@@ -142,6 +142,7 @@ def main() -> None:
         "repositories": dict(),
         "repository_query": repo_query,
     }
+    repos_sent_events = []
     for repo in repos:
         core.start_group(repo.full_name)
         repo_status: dict = dict()
@@ -185,15 +186,17 @@ def main() -> None:
                     rebuilds_triggered,
                     repo.full_name,
                 )
-                core.notice(
-                    f"Sent {event_type} ({rebuilds_triggered}/{max_rebuilds})",
-                    title=repo.full_name,
-                )
+                repos_sent_events.append(repo.full_name)
                 if rebuilds_triggered == max_rebuilds:
                     logging.warning("Max rebuild events sent.")
         else:
             logging.info("%s is OK: %s", repo.full_name, format_timedelta(delta))
         core.end_group()
+
+    core.notice(
+        "\n".join(["Repositories sent events:", *repos_sent_events]),
+        title=f"Sent {rebuilds_triggered} '{event_type}' events",
+    )
 
     # Write json state to an output file
     status_file: Path = Path(github_workspace_dir) / Path(write_filename)


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds enhanced logging that is specific to GitHub Actions.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

This mirrors some of the work done in [cisagov/action-lineage](https://github.com/cisagov/action-lineage) where the logging output is grouped by repository and workflow notifications are leveraged for important output.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. This version was used in [this Actions run](https://github.com/cisagov/action-apb/actions/runs/1748305680).
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
