### PR TITLE
Provide configuration to handle non-public repositories

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,16 @@ inputs:
     description: "repository_dispatch event type to send."
     required: false
     default: "apb"
+  include_non_public_repos:
+    default: false
+    description: "Whether to process non-public (`private` and `internal`)
+      repositories."
+    required: false
+  mask_non_public_repos:
+    default: true
+    description: "Whether to mask the names of non-public (`private` and
+      `internal`) repositories in the GitHub Actions logs."
+    required: false
   max_rebuilds:
     description: "Limit the number of rebuilds that will be triggered."
     required: false

--- a/src/apb/entrypoint.py
+++ b/src/apb/entrypoint.py
@@ -69,7 +69,9 @@ def get_last_run(workflow: Workflow.Workflow, target_branch: str) -> Optional[da
 def main() -> None:
     """Parse evironment and perform requested actions."""
     # Set up logging
-    logging.basicConfig(format="%(levelname)s %(message)s", level="INFO")
+    logging.basicConfig(
+        format="%(levelname)s %(message)s", level=logging.INFO, stream=sys.stdout
+    )
 
     # Get inputs from the environment
     access_token: Optional[str] = os.environ.get("INPUT_ACCESS_TOKEN")

--- a/src/apb/entrypoint.py
+++ b/src/apb/entrypoint.py
@@ -76,6 +76,8 @@ def main() -> None:
     build_age: Optional[str] = os.environ.get("INPUT_BUILD_AGE")
     event_type: Optional[str] = os.environ.get("INPUT_EVENT_TYPE")
     github_workspace_dir: Optional[str] = os.environ.get("GITHUB_WORKSPACE")
+    include_non_public: bool = core.get_boolean_input("include_non_public_repos")
+    mask_non_public: bool = core.get_boolean_input("mask_non_public_repos")
     max_rebuilds: int = int(os.environ.get("INPUT_MAX_REBUILDS", 10))
     repo_query: Optional[str] = os.environ.get("INPUT_REPO_QUERY")
     workflow_id: Optional[str] = os.environ.get("INPUT_WORKFLOW_ID")
@@ -144,6 +146,13 @@ def main() -> None:
     }
     repos_sent_events = []
     for repo in repos:
+        # Extra controls if the repo is non-public
+        if repo.private:
+            if not include_non_public:
+                continue
+            # Ensure that non-public repo names do not show up in the logs
+            if mask_non_public:
+                core.set_secret(repo.full_name)
         core.start_group(repo.full_name)
         repo_status: dict = dict()
         all_repo_status["repositories"][repo.full_name] = repo_status


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds controls to manage interactions with non-public repositories. These controls manage whether or not non-public repositories should be processed and if non-public repositories are processed if their names should be masked in the GitHub Actions log output.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Blindly processing non-public repositories can lead to unintended information leakage. This also mirrors functionality added in https://github.com/cisagov/action-lineage/pull/38.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
