### PR TITLE
Mask non-public repositories in the run artifact

### DIFF
--- a/src/apb/entrypoint.py
+++ b/src/apb/entrypoint.py
@@ -148,16 +148,18 @@ def main() -> None:
     }
     repos_sent_events = []
     for repo in repos:
+        repo_status: dict = dict()
+        all_repo_status["repositories"][repo.full_name] = repo_status
         # Extra controls if the repo is non-public
         if repo.private:
             if not include_non_public:
+                del all_repo_status["repositories"][repo.full_name]
                 continue
             # Ensure that non-public repo names do not show up in the logs
             if mask_non_public:
                 core.set_secret(repo.full_name)
+                del all_repo_status["repositories"][repo.full_name]
         core.start_group(repo.full_name)
-        repo_status: dict = dict()
-        all_repo_status["repositories"][repo.full_name] = repo_status
         target_workflow = get_workflow(repo, workflow_id)
         if target_workflow is None:
             # Repo does not have the workflow configured


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request updates to handle removing repositories from the produced build artifact when processing non-public repositories but masking their names.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

There is no point to masking non-public repository names from the GitHub Actions log if they're just going to be in the build artifact (and by extension in the wiki through [cisagov/action-apb-dashboard](https://github.com/cisagov/action-apb-dashboard)).
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
