### PR TITLE
Validate the workflow when checking repositories

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ setup(
         "PyGithub",
         "python-dateutil",
         "pytimeparse",
+        "ruamel.yaml",
         "setuptools >= 24.2.0",
     ],
     extras_require={

--- a/src/apb/entrypoint.py
+++ b/src/apb/entrypoint.py
@@ -78,6 +78,10 @@ def validate_workflow(repo: Repository.Repository, workflow: Workflow.Workflow) 
 
     workflow_yaml = ruamel.yaml.safe_load(workflow_file.decoded_content)
 
+    # This next section validates that the workflow file is configured to
+    # process `apb` repository dispatch events. Please see
+    # https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#repository_dispatch
+    # for more information.
     workflow_triggers = workflow_yaml.get("on", {})
     repository_dispatches: Optional[dict]
     repository_dispatch_types: Optional[list]
@@ -94,6 +98,8 @@ def validate_workflow(repo: Repository.Repository, workflow: Workflow.Workflow) 
             else None
         )
 
+    # We either need a blanket `repository_dispatch` trigger or for `apb` to be
+    # in the optional `types` subkey.
     if repository_dispatches is None or (
         repository_dispatch_types is not None and "apb" not in repository_dispatch_types
     ):

--- a/src/apb/entrypoint.py
+++ b/src/apb/entrypoint.py
@@ -78,11 +78,25 @@ def validate_workflow(repo: Repository.Repository, workflow: Workflow.Workflow) 
 
     workflow_yaml = ruamel.yaml.safe_load(workflow_file.decoded_content)
 
-    repository_dispatch_types = (
-        workflow_yaml.get("on", {}).get("repository_dispatch", {}).get("types", [])
-    )
+    workflow_triggers = workflow_yaml.get("on", {})
+    repository_dispatches: Optional[dict]
+    repository_dispatch_types: Optional[list]
+    if type(workflow_triggers) == list:
+        repository_dispatches = (
+            {} if "repository_dispatch" in workflow_triggers else None
+        )
+        repository_dispatch_types = None
+    else:
+        repository_dispatches = workflow_triggers.get("repository_dispatch", None)
+        repository_dispatch_types = (
+            repository_dispatches.get("types", None)
+            if repository_dispatches is not None
+            else None
+        )
 
-    if "apb" not in repository_dispatch_types:
+    if repository_dispatches is None or (
+        repository_dispatch_types is not None and "apb" not in repository_dispatch_types
+    ):
         logging.info(
             "Workflow file '%s' in %s does not support apb repository dispatch",
             workflow.path,

--- a/src/apb/entrypoint.py
+++ b/src/apb/entrypoint.py
@@ -76,7 +76,15 @@ def validate_workflow(repo: Repository.Repository, workflow: Workflow.Workflow) 
 
         return False
 
-    workflow_yaml = ruamel.yaml.safe_load(workflow_file.decoded_content)
+    try:
+        workflow_yaml = ruamel.yaml.safe_load(workflow_file.decoded_content)
+    except ruamel.yaml.YAMLError:
+        logging.exception("Unable to process '%s' in %s", workflow.path, repo.full_name)
+        core.warning(
+            f"Workflow file '{workflow.path}' is possibly malformed.",
+            title=repo.full_name,
+        )
+        return False
 
     # This next section validates that the workflow file is configured to
     # process `apb` repository dispatch events. Please see


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds logic to validate the workflow when checking a repository. This ensures that before checking the repository we know that it is able to process the `repository_dispatch` event that would be sent.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

There are a number of repositories that do not have workflows configured to support the functionality in this action. Since these repositories cannot process `apb` repository dispatches they will continue to use up dispatch slots until another process (manual intervention, a Lineage update, etc) causes their workflow to be run. This is undesirable behavior so we should filter out, and alert about, repositories that cannot process `apb` repository dispatches.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. This version ran with no issues in [this](https://github.com/cisagov/action-apb/actions/runs/1813906155) Action run.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - _eschew scope creep!_
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
