### PR TITLE
Explicitly set the author email in the `rebuild_org` workflow

### DIFF
--- a/.github/workflows/rebuild_org.yml
+++ b/.github/workflows/rebuild_org.yml
@@ -44,6 +44,7 @@ jobs:
           git remote set-url origin \
           https://$GITHUB_ACTOR:$ACCESS_TOKEN@github.com/$GITHUB_REPOSITORY.wiki.git
           git config --global user.name $GITHUB_ACTOR
+          git config --global user.email $GITHUB_ACTOR@github.com
           git add .
           git commit -m "$GITHUB_EVENT_NAME"
           git push


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request explicitly sets the git author email in the `rebuild_org` workflow's `Commit changes to wiki` step.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

Recently there have been intermittent failures at this step in runs of that workflow. It appears to stem from being unable to auto-detect a fully formed email address on the GitHub Actions runner. This change fully aligns this step with how the [cisagov/action-lineage sets git author information](https://github.com/cisagov/action-lineage/blob/0bd34e5425ca227e3f798faf689d1dbe9a799018/src/lineage/entrypoint.py#L158-L164).
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass (except the Python 3.6 test which fails because of a GitHub Actions runner issue). The updated workflow ran with no issues in [this run](https://github.com/cisagov/action-apb/actions/runs/3673696042/jobs/6211048922#step:8:15).
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
