### PR TITLE
Update Action versions used in the `rebuild_org` workflow

### DIFF
--- a/.github/workflows/rebuild_org.yml
+++ b/.github/workflows/rebuild_org.yml
@@ -25,14 +25,14 @@ jobs:
           repo_query: "org:cisagov archived:false"
           workflow_id: "build.yml"
       - name: Save apb output as an artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v3
         with:
           name: apb.json
           path: apb.json
       - name: Generate markdown
         uses: cisagov/action-apb-dashboard@develop
       - name: Checkout wiki
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           path: wiki
           repository: "${{ github.repository }}.wiki"


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Bump the following Actions versions to match those used in the `build` workflow:
- [actions/checkout] from v2 to v4
- [actions/upload-artifact] from v2 to v3

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

The workflow running on the `develop` branch current fails when trying to checkout the repo wiki as seen [here](https://github.com/cisagov/action-apb/actions/runs/9577645041). I surmised it was due to the somewhat ancient version of [actions/checkout] being used. Since Action versions should be kept in sync I upgraded the Actions used in the `rebuild_org` workflow to match the `build` workflow. This resulted in a successful run using this branch as seen [here](https://github.com/cisagov/action-apb/actions/runs/9568961722https://github.com/cisagov/action-apb/actions/runs/9568961722).
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. As mentioned above the workflow completes successfully when using this branch.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

[actions/checkout]: https://github.com/actions/checkout
[actions/upload-artifact]: https://github.com/actions/upload-artifact
