### PR TITLE
Unset Certificate Authority related variables if running in GitHub Actions

### DIFF
--- a/src/apb/_version.py
+++ b/src/apb/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "2.0.0"
+__version__ = "2.0.1"

--- a/src/apb/entrypoint.py
+++ b/src/apb/entrypoint.py
@@ -18,6 +18,16 @@ import pytimeparse
 import requests
 
 
+def clear_ca_variables_in_gha() -> None:
+    """Unset CA variables if running in GitHub Actions."""
+    logging.info("Clearing CA variables...")
+    # Only remove variables we care about
+    for ca_variable in ["REQUESTS_CA_BUNDLE"]:
+        if ca_variable in os.environ:
+            del os.environ[ca_variable]
+            logging.info("Removed %s from environment.", ca_variable)
+
+
 def get_repo_list(
     g: Github, repo_query: str
 ) -> Generator[Repository.Repository, None, None]:
@@ -101,6 +111,13 @@ def main() -> None:
             "Output filename environment variable must be set. (INPUT_WRITE_FILENAME)"
         )
         sys.exit(-1)
+
+    # If the GITHUB_ACTIONS environment variable is set to true it should indicate
+    # that we are running in GitHub Actions. Please see the following documentation
+    # for more information:
+    # https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
+    if os.environ.get("GITHUB_ACTIONS", "false") == "true":
+        clear_ca_variables_in_gha()
 
     # setup time calculations
     now: datetime = datetime.utcnow()

--- a/tests/test_apb.py
+++ b/tests/test_apb.py
@@ -8,10 +8,18 @@ import pytest
 
 # cisagov Libraries
 import apb
+import apb.entrypoint
 
 # define sources of version strings
 PROJECT_VERSION = apb.__version__
 RELEASE_TAG = os.getenv("RELEASE_TAG")
+
+
+def test_unset_ca_variables():
+    """Test that CA variables are unset."""
+    os.environ["REQUESTS_CA_BUNDLE"] = "test"
+    apb.entrypoint.clear_ca_variables_in_gha()
+    assert "REQUESTS_CA_BUNDLE" not in os.environ
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

This pull request adds functionality to unset Certificate Authority (CA) related variables that would impact this project if it detects it is running in GitHub Actions.
<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

## 💭 Motivation and context ##

With the addition of the [GitHubSecurityLab/actions-permissions/monitor] Action the `rebuild_org` workflow is unable to run successfully. This is because the proxy set up by that Action requires it to set a number of CA environment variables so tools know to use the generated certificate. However, since this project runs as a Docker Action it inherits the environment variables but not the certificate. The solution I came to was unsetting any relevant environment variables if the package thinks it is running in GitHub Actions.
<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

## 🧪 Testing ##

Automated tests pass. I used this branch's code to successfully run workflow dispatches.
<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [x] Create a release.
- [x] Re-enable the `rebuild_org` workflow.

[GitHubSecurityLab/actions-permissions/monitor]: https://github.com/GitHubSecurityLab/actions-permissions/tree/main/monitor