### PR TITLE
Check most recent build on default branch

### DIFF
--- a/src/apb/_version.py
+++ b/src/apb/_version.py
@@ -1,3 +1,3 @@
 """This file defines the version of this module."""
 
-__version__ = "2.0.1"
+__version__ = "2.1.0"

--- a/src/apb/entrypoint.py
+++ b/src/apb/entrypoint.py
@@ -60,7 +60,7 @@ def get_last_run_on_default_branch(
         )
         return None
 
-    # Find the date of the most recent workflow run against the default branch.
+    # Find the date of the most recent workflow run against the default branch
     last_run_date = None
     for run in response.json()["workflow_runs"]:
         if run["head_branch"] == default_branch:

--- a/src/apb/entrypoint.py
+++ b/src/apb/entrypoint.py
@@ -37,11 +37,20 @@ def get_repo_list(
     yield from matching_repos
 
 
-def get_last_run(
+def get_last_run_on_default_branch(
     session: requests.Session, repo: Repository.Repository, workflow_id: str
 ) -> Optional[datetime]:
-    """Get the last run time for a workflow in a respository."""
-    logging.debug(f"Requesting workflow runs for repository {repo.name}")
+    """Get last run time for a workflow on default branch in a respository."""
+    logging.debug(f"Requesting repository information for repository {repo.name}")
+    response = session.get(f"https://api.github.com/repos/{repo.full_name}")
+    if response.status_code != 200:
+        logging.debug(f"Invalid repository {repo.full_name}, {response.status_code}")
+        return None
+    default_branch = response.json()["default_branch"]
+
+    logging.debug(
+        f"Requesting workflow runs on {default_branch} for repository {repo.name}"
+    )
     response = session.get(
         f"https://api.github.com/repos/{repo.full_name}/actions/workflows/{workflow_id}/runs"
     )
@@ -51,10 +60,13 @@ def get_last_run(
         )
         return None
     workflow_runs = response.json()["workflow_runs"]
-    if len(workflow_runs) == 0:
+    workflow_runs_on_default_branch = [
+        run for run in workflow_runs if run["head_branch"] == default_branch
+    ]
+    if len(workflow_runs_on_default_branch) == 0:
         return None
     else:
-        last_run_date = workflow_runs[0]["created_at"]
+        last_run_date = workflow_runs_on_default_branch[0]["created_at"]
         return isoparse(last_run_date).replace(tzinfo=None)
 
 
@@ -148,7 +160,7 @@ def main() -> None:
     for repo in repos:
         repo_status: dict = dict()
         all_repo_status["repositories"][repo.full_name] = repo_status
-        last_run = get_last_run(session, repo, workflow_id)
+        last_run = get_last_run_on_default_branch(session, repo, workflow_id)
         if last_run is None:
             # repo does not have the workflow configured
             logging.info(f"{repo.full_name} does not have workflow {workflow_id}")

--- a/src/apb/entrypoint.py
+++ b/src/apb/entrypoint.py
@@ -59,16 +59,15 @@ def get_last_run_on_default_branch(
             f"No previous runs for {workflow_id} in {repo.full_name}, {response.status_code}"
         )
         return None
-    workflow_runs_on_default_branch = [
-        run
-        for run in response.json()["workflow_runs"]
-        if run["head_branch"] == default_branch
-    ]
-    if len(workflow_runs_on_default_branch) == 0:
-        return None
-    else:
-        last_run_date = workflow_runs_on_default_branch[0]["created_at"]
-        return isoparse(last_run_date).replace(tzinfo=None)
+
+    # Find the date of the most recent workflow run against the default branch.
+    last_run_date = None
+    for run in response.json()["workflow_runs"]:
+        if run["head_branch"] == default_branch:
+            last_run_date = isoparse(run["created_at"]).replace(tzinfo=None)
+            break
+
+    return last_run_date
 
 
 def main() -> None:

--- a/src/apb/entrypoint.py
+++ b/src/apb/entrypoint.py
@@ -59,9 +59,10 @@ def get_last_run_on_default_branch(
             f"No previous runs for {workflow_id} in {repo.full_name}, {response.status_code}"
         )
         return None
-    workflow_runs = response.json()["workflow_runs"]
     workflow_runs_on_default_branch = [
-        run for run in workflow_runs if run["head_branch"] == default_branch
+        run
+        for run in response.json()["workflow_runs"]
+        if run["head_branch"] == default_branch
     ]
     if len(workflow_runs_on_default_branch) == 0:
         return None


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the Python code to check the most recent build _on the default branch_ when determining build status.

## 💭 Motivation and context ##

Resolves #68.

## 🧪 Testing ##

All automated tests pass.  I also ran the code locally (commenting out the actual call to kick off a new APB build) and verified that it functions as expected.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.
- [x] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).

## ✅ Pre-merge checklist ##

- [x] Finalize version.

## ✅ Post-merge checklist ##

- [x] Create a release (necessary if and only if the version was bumped).