### PR TITLE
Update schedule to allow unfettered runs on the weekend

### DIFF
--- a/.github/workflows/rebuild_org.yml
+++ b/.github/workflows/rebuild_org.yml
@@ -7,7 +7,13 @@ on:  # yamllint disable-line rule:truthy
       - run_tmate
       - run
   schedule:
-    - cron: 0 0-4 * * *
+    # Run hourly from about 7PM until 4AM Eastern time, Sunday evening
+    # through Monday morning, Monday evening through Tuesday morning,
+    # ..., Thursday evening through Friday morning.
+    - cron: 0 0-9 * * 1-5
+    # Run hourly from about 7PM Eastern time, Friday evening through
+    # Sunday evening.
+    - cron: 0 * * * 0,6
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
## 🗣 Description ##

This pull request modifies the `rebuild_org.yml` GitHub Actions workflow to run:
- Hourly from about 7PM until 4AM Eastern time, Sunday evening through Monday morning, Monday evening through Tuesday morning,..., Thursday evening through Friday morning.
- Hourly from about 7PM Eastern time, Friday evening through Sunday evening.

## 💭 Motivation and context ##

We may as well allow unfettered runs when nobody else is using the runners.

## 🧪 Testing ##

All automated tests pass.

## ✅ Pre-approval checklist ##

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All new and existing tests pass.